### PR TITLE
Correct the encoding scheme of access token hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,16 @@ SingPass:
  - http://localhost:5156/singpass/soap - receives SAML artifact and returns assertion
  - http://localhost:5156/singpass/authorize - OIDC login redirect with optional page
  - http://localhost:5156/singpass/token - receives OIDC authorization code and returns id_token
+ - http://localhost:5156/singpass/metadata - metadata endpoint
+ - http://localhost:5156/singpass/spcplogout - do nothing but redirect to the provided return_url query parameter
 
 CorpPass:
  - http://localhost:5156/corppass/logininitial
  - http://localhost:5156/corppass/soap
  - http://localhost:5156/corppass/authorize - OIDC login redirect with optional page
  - http://localhost:5156/corppass/token - receives OIDC authorization code and returns id_token
+ - http://localhost:5156/corppass/metadata - metadata endpoint
+ - http://localhost:5156/corppass/spcplogout - do nothing but redirect to the provided return_url query parameter
 
 MyInfo:
  - http://localhost:5156/myinfo/{v2,v3}/person-basic (exclusive to government systems)

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -1,4 +1,5 @@
 const base64 = require('base-64')
+const base64url = require('base64url')
 const crypto = require('crypto')
 const fs = require('fs')
 const { render } = require('mustache')
@@ -19,7 +20,8 @@ const hashAccessToken = (accessToken) => {
   const fullHash = crypto.createHash('sha256')
   fullHash.update(accessToken, 'utf8')
   const fullDigest = fullHash.digest()
-  return fullDigest.slice(0, fullDigest.length / 2).toString('base64')
+  const base64string = fullDigest.slice(0, fullDigest.length / 2).toString('base64')
+  return base64url.fromBase64(base64string)
 }
 
 const myinfo = {

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -240,8 +240,51 @@ const oidc = {
       const accessTokenClaims = {
         ...baseClaims,
         authorization: {
-          EntityInfo: {},
-          AccessInfo: {},
+          EntityInfo: {
+            "CPEntID":"R90SS0001A",
+            "CPEnt_Status":"Registered",
+            "CPEnt_TYPE":"UEN",
+            "CPNonUEN_RegNo":"",
+            "CPNonUEN_Country":"",
+            "CPNonUEN_Name":""
+          },
+          AccessInfo: {
+            "Result_Set":{
+              "ESrvc_Row_Count":1,
+              "ESrvc_Result":[
+                 {
+                    "CPESrvcID":"BGESRV1",
+                    "Auth_Result_Set":{
+                       "Row_Count":2,
+                       "Row":[
+                          {
+                             "CPEntID_SUB":"",
+                             "CPRole":"",
+                             "StartDate":"2016-01-15",
+                             "EndDate":"2016-02-15"
+                          },
+                          {
+                             "CPEntID_SUB":"",
+                             "CPRole":"",
+                             "StartDate":"2016-03-15",
+                             "EndDate":"2017-04-15",
+                             "Parameter":[
+                                {
+                                   "name":"Year of assessment",
+                                   "value":"2014"
+                                },
+                                {
+                                   "name":"other02",
+                                   "value":"value 02"
+                                }
+                             ]
+                          }
+                       ]
+                    }
+                 }
+              ]
+            }
+          },
           TPAccessInfo: {},
         },
       }
@@ -269,9 +312,9 @@ const oidc = {
           sub,
           ...(nonce ? { nonce } : {}),
           userInfo: {
-            CPAccType: 'User',
-            CPUID_FullName: profile.name,
-            ISSPHOLDER: profile.isSingPassHolder ? 'YES' : 'NO',
+            "CPAccType": 'User',
+            "CPUID_FullName": profile.name,
+            "ISSPHOLDER": profile.isSingPassHolder ? 'YES' : 'NO',
           },
         },
       }

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -63,6 +63,12 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       res.redirect(redirectURI)
     })
 
+    app.post(`/${idp.toLowerCase()}/spcplogout`, (req, res) => {
+      const redirectURI = req.query.return_url
+      console.info(`SPCP logout is done, now redirecting to ${redirectURI}`)
+      res.redirect(redirectURI)
+    })
+
     app.get(`/${idp.toLowerCase()}/authorize`, (req, res) => {
       const redirectURI = req.query.redirect_uri
       const state = encodeURIComponent(req.query.state)

--- a/lib/express/oidc.js
+++ b/lib/express/oidc.js
@@ -56,6 +56,12 @@ function config(app, { showLoginPage, idpConfig, serviceProvider }) {
       )
       res.send(JSON.parse(jwks))
     })
+    
+    app.get(`/${idp.toLowerCase()}/spcplogout`, (req, res) => {
+      const redirectURI = req.query.return_url
+      console.info(`SPCP logout is done, now redirecting to ${redirectURI}`)
+      res.redirect(redirectURI)
+    })
 
     app.get(`/${idp.toLowerCase()}/authorize`, (req, res) => {
       const redirectURI = req.query.redirect_uri


### PR DESCRIPTION
Why:
- Mockpass originally use base64 for encoding access token while SPCP interface specification states that base64 URL is used for payload encoding
- the oauth2/oidc-specified libraries also take bas64 URL for decoding access token hash
- the mismatched between those two encoding scheme leading to access token hash validation always failed
- example for base64 vs base64 URL difference: 'nu6W4Iw9X+Juh0XFzqq1Bw==' versus 'nu6W4Iw9X-Juh0XFzqq1Bw'

How:
- correct the encoding scheme when hashing the access token